### PR TITLE
Refresh Token

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,18 @@ request an access token from the provider::
 
     c.request_token(response_dict)
 
+Refresh Token
+`````````````
+If the OAuth provider returns a ``refresh_token``, it will be available after
+the call to ``request_token`` as ``client.refresh_token``. You can save this token
+and use it later to request another access token::
+
+    c.use_refresh_token(refresh_token)
+
+You can use this code instead of the usual ``auth_uri`` and ``request_token`` dance
+when you already have a refresh token and the access token expires.
+
+:note: Not all providers use refresh tokens.
 
 Resource Request
 ````````````````

--- a/sanction/client.py
+++ b/sanction/client.py
@@ -49,6 +49,22 @@ class Client(object):
         self.__get_access_token(self.client_id,
             self.client_secret, parser=parser, **kwargs)
 
+    def use_refresh_token(self, refresh_token, parser=None):
+        if parser is None:
+            parser = loads
+        request_data = {
+            'grant_type': 'refresh_token',
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'refresh_token': refresh_token,
+        }
+        response = urlopen(self.token_endpoint, urlencode(request_data))
+        response_data = parser(response.read())
+
+        for key in response_data:
+            setattr(self, key, response_data[key])
+
+        assert(self.access_token is not None)
 
     def request(self, path, qs=None, data=None, parser=None):
         assert(self.access_token is not None)


### PR DESCRIPTION
I added the ability to use a refresh token to get a new access token. I know this isn't widely supported, but it is part of the spec.

I wasn't really sure how to add any tests for this, but I have tested it manually with the Salesforce OAuth provider.
