### PR TITLE
Updated link to GitHub Oauth page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ sanction has been tested with the following OAuth2 providers:
 .. _Facebook: https://developers.facebook.com/docs/authentication/
 .. _Google: https://developers.google.com/accounts/docs/OAuth2
 .. _Foursquare: https://developer.foursquare.com/overview/auth
-.. _GitHub: http://develop.github.com/p/oauth.html
+.. _GitHub: http://developer.github.com/v3/oauth/
 .. _Instagram: http://instagram.com/developer/
 .. _bitly: http://dev.bitly.com/api.html
 .. _StackExchange: https://api.stackexchange.com/docs


### PR DESCRIPTION
Old link pointed to a 404
