### PR TITLE
Add support for raw responses

### DIFF
--- a/sanction/__init__.py
+++ b/sanction/__init__.py
@@ -145,7 +145,7 @@ class Client(object):
         self.request_token(refresh_token=self.refresh_token,
             grant_type='refresh_token')
 
-    def request(self, url, method=None, data=None, headers=None, parser=None): 
+    def request(self, url, method=None, data=None, headers=None, parser=None, raw=False):
         """ Request user data from the resource endpoint
         :param url: The path to the resource and querystring if required
         :param method: HTTP method. Defaults to ``GET`` unless data is not None
@@ -153,6 +153,7 @@ class Client(object):
         :param data: Data to be POSTed to the resource endpoint
         :param parser: Parser callback to deal with the returned data. Defaults
                        to ``json.loads`.`
+        :param raw: If the raw response object should be returned
         """
         assert self.access_token is not None
         parser = parser or loads 
@@ -164,6 +165,12 @@ class Client(object):
             url), self.access_token, data=data, method=method, headers=headers)
 
         resp = urlopen(req)
+
+        # return the response object if a raw response is requested
+        if raw:
+            return resp
+
+        # otherwise read the data and parse it
         data = resp.read()
         try:
             return parser(data.decode(resp.info().get_content_charset() or


### PR DESCRIPTION
Sometimes it can be very useful to be able to access the raw response object, instead of it being automatically read and passes through the specified parser. That way, one can access the response headers and read additional information from there.

For example, GitHub’s API will put [rate limit information](https://dev.twitter.com/docs/rate-limiting/1.1) into `X-Rate-Limit-*` headers. With the current means, there is no possibility to access this information—other than requesting the [rate limit status](https://dev.twitter.com/docs/api/1.1/get/application/rate_limit_status) itself separately.

Another useful example is the StackExchange gzip compression which is part of your example. Usually, you shouldn’t blindly decompress responses just because you know that the server returns compressed results. Instead, servers are required to send the `Content-Encoding` HTTP header, specifying the used compression. Unless that header is set, you shouldn’t decompress it.

This pull requests adds an optional `raw` parameter to the `Client.request` method. Setting this to `True` will make the client return the raw response object instead of reading it and parsing it with the `parser`.

For the StackExchange example, it could be used like this then:

```
response = client.request('/query', raw=True)
content = response.read()
if response.headers.get('content-encoding') == 'gzip':
    content = gzip.decompress(content)
data = json.loads(content.decode())
```

Going further, it might make sense to actually pass the request object to the parser directly, passing all available information to it. But I didn’t want to introduce too many changes now, and especially didn’t want to break the compatibility.
