### PR TITLE
Update __init__.py bugfix for expirex_int

### DIFF
--- a/sanction/__init__.py
+++ b/sanction/__init__.py
@@ -138,8 +138,13 @@ class Client(object):
         # expires_in is RFC-compliant. if anything else is used by the
         # provider, token_expires must be set manually
         if hasattr(self, 'expires_in'):
+            try:
+                # python3 dosn't support long
+                seconds = long(self.expires_in)
+            except:
+                seconds = int(self.expires_in)
             self.token_expires = mktime((datetime.utcnow() + timedelta(
-                seconds=long(self.expires_in))).timetuple())
+                seconds=seconds)).timetuple())
 
     def refresh(self):
         self.request_token(refresh_token=self.refresh_token,

--- a/sanction/__init__.py
+++ b/sanction/__init__.py
@@ -139,7 +139,7 @@ class Client(object):
         # provider, token_expires must be set manually
         if hasattr(self, 'expires_in'):
             self.token_expires = mktime((datetime.utcnow() + timedelta(
-                seconds=self.expires_in)).timetuple())
+                seconds=long(self.expires_in))).timetuple())
 
     def refresh(self):
         self.request_token(refresh_token=self.refresh_token,


### PR DESCRIPTION
Convert self.expires_in to long. In my case, I got a string type of expires_in that broken the execution. So I covert it to long to make that works.
