### PR TITLE
Just delete client.py

### DIFF
--- a/sanction/client.py
+++ b/sanction/client.py
@@ -1,3 +1,0 @@
-from warnings import warn
-warn('sanction.client.Client is deprecated, please use sanction.Client')
-from sanction import Client


### PR DESCRIPTION
Come on. It was deprecated in 2013. Fixing the calling code is trivial, and if you want to stay on old version, just stay on the old version.