### PR TITLE
docs: fix simple typo, teseted -> tested

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ sanction has been tested with the following OAuth2 providers:
 
 :note: The intention of the sanction library is to not only provide accessibility
        to the OAuth2 authorization code flow, but all server-side flows. However,
-       due to lack of implementations, the only tested currently teseted flows
+       due to lack of implementations, the only tested currently tested flows
        are authorization code and client credentials.
 
 


### PR DESCRIPTION
There is a small typo in docs/index.rst.

Should read `tested` rather than `teseted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md